### PR TITLE
return instead of StopIteration when done draining

### DIFF
--- a/sqs_queue.py
+++ b/sqs_queue.py
@@ -48,7 +48,7 @@ class Queue(object):
                     message.delete()
             if not messages:
                 if self.drain:
-                    raise StopIteration
+                    return
                 sleep(self.poll_sleep)
 
     def publish(self, body, **kwargs):


### PR DESCRIPTION
### Description
Since 2014 raising `StopIteration` to terminate a generator has been deprecated, and in recent Python versions it raises `RuntimeError` instead. `return`ing instead of `yield`ing is the correct way to terminate a generator. https://www.python.org/dev/peps/pep-0479/
