### PR TITLE
PDT-3647 Bulk-queue handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+
+COPY setup.py .
+COPY sqs_queue.py .
+COPY README.md .
+
+RUN pip install -e . ipython
+
+CMD ["ipython"]

--- a/README.md
+++ b/README.md
@@ -45,14 +45,13 @@ my_queue = Queue(queue=queue_resource)
 
 You can put your AWS credentials in environment variables or [any of the other places boto3 looks](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html).
 
-## Parameters
+Other parameters can be passed into the `Queue()` initiator, or set with environment variables prefixed by `SQS_QUEUE_`, e.g. `SQS_QUEUE_POLL_WAIT`.
 
+## Parameters
 
 ### `poll_wait` and `poll_sleep`
 
-Behind the scenes, the generator is polling SQS for new messages. When the queue is empty, that
-call will wait up to 20 seconds for new messages, and if it times out before any arrive it will
-sleep for 40 seconds before trying again. Those time intervals are configurable:
+Behind the scenes, the generator is polling SQS for new messages. When the queue is empty, that call will wait up to 20 seconds for new messages, and if it times out before any arrive it will sleep for 40 seconds before trying again. Those time intervals are configurable:
 
 ```py
 queue = Queue('YOUR_QUEUE_NAME', poll_wait=20, poll_sleep=40)

--- a/README.md
+++ b/README.md
@@ -80,3 +80,36 @@ When you use this option, the `sns_message_id` is added to the notification data
 ### `create`
 
 When you pass `create=True` then, if your SQS queue name is not found, a queue with that name will be created.
+
+### `bulk_queue`
+
+You can pass this option another `Queue`, which will be checked only when the primary "priority" queue is empty. For example:
+
+```
+In [1]:   from sqs_queue import Queue
+
+In [2]:   bulk = Queue(
+   ...:       queue_name='bulk',
+   ...:       create=True,
+   ...:       poll_wait=2
+   ...:   )
+
+In [3]:   primary = Queue(
+   ...:       queue_name='primary',
+   ...:       bulk_queue=bulk,
+   ...:       drain=True,
+   ...:       create=True,
+   ...:       poll_wait=2
+   ...:   )
+
+In [5]:   primary.publish('{"type": "priority", "id": 1}')
+   ...:   bulk.publish('{"type": "bulk", "id": 1}')
+   ...:   bulk.publish('{"type": "bulk", "id": 2}')
+
+In [6]:   for msg in primary:
+   ...:       print(msg)
+
+{'type': 'priority', 'id': 1}
+{'type': 'bulk', 'id': 1}
+{'type': 'bulk', 'id': 2}
+```

--- a/README.md
+++ b/README.md
@@ -112,3 +112,17 @@ In [6]:   for msg in primary:
 {'type': 'bulk', 'id': 1}
 {'type': 'bulk', 'id': 2}
 ```
+
+### `bulk_queue_check_pct`
+
+When using `bulk_queue`, the bulk queue is normally only checked when the primary queue is empty. With `bulk_queue_check_pct`, you can also randomly check the bulk queue after a percentage of non-empty primary queue polls:
+
+```py
+primary = Queue(
+    queue_name='primary',
+    bulk_queue=bulk,
+    bulk_queue_check_pct=25
+)
+```
+
+This will check the bulk queue after approximately 25% of primary queue polls that returned messages, helping prevent bulk messages from being starved when the primary queue is continuously busy.

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,19 @@
+services:
+  localstack:
+    image: localstack/localstack:4.3
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"
+
+  ipython:
+    build: .
+    stdin_open: true
+    tty: true
+    depends_on:
+      - localstack
+    environment:
+      - AWS_ACCESS_KEY_ID=test
+      - AWS_SECRET_ACCESS_KEY=test
+      - AWS_DEFAULT_REGION=us-east-1
+      - AWS_ENDPOINT_URL=http://localstack:4566

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='sqs_queue',
-    version='0.6.7',
+    version='1.0.0',
     description='AWS SQS queue consumer/publisher',
     author='Nic Wolff',
     author_email='nwolff@hearst.com',

--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,5 @@ setup(
     long_description_content_type="text/markdown",
     url='http://github.com/Media-Platforms/py-sqs-queue',
     py_modules=['sqs_queue'],
-    install_requires=['boto3']
+    install_requires=['boto3', 'cast_from_env']
 )

--- a/sqs_queue.py
+++ b/sqs_queue.py
@@ -180,6 +180,8 @@ class Queue(object):
             return None
 
     def publish(self, body, **kwargs):
+        if isinstance(body, dict):
+            body = json.dumps(body)
         self.queue.send_message(MessageBody=body, **kwargs)
 
     def make_sigterm_handler(self):

--- a/sqs_queue.py
+++ b/sqs_queue.py
@@ -9,11 +9,6 @@ import boto3
 logger = getLogger(__name__)
 
 
-def utc_from_timestamp(message, attribute):
-    ts = message.attributes.get(attribute)
-    return datetime.fromtimestamp(int(ts) / 1000, timezone.utc) if ts else None
-
-
 class Queue(object):
     got_sigterm = False
 
@@ -200,3 +195,8 @@ class Message(dict):
 
     def defer(self):
         self.queue.consumer.send(True)
+
+
+def utc_from_timestamp(message, attribute):
+    ts = message.attributes.get(attribute)
+    return datetime.fromtimestamp(int(ts) / 1000, timezone.utc) if ts else None

--- a/test.py
+++ b/test.py
@@ -808,6 +808,15 @@ class TestQueuePublish(TestCase):
             MessageGroupId='group1'
         )
 
+    def test_converts_dict_to_json(self):
+        mock_queue = MagicMock()
+        with patch('sqs_queue.signal'):
+            q = Queue(queue=mock_queue)
+            q.publish({'key': 'value', 'number': 42})
+        mock_queue.send_message.assert_called_once_with(
+            MessageBody='{"key": "value", "number": 42}'
+        )
+
 
 class TestMakeSigtermHandler(TestCase):
 

--- a/test.py
+++ b/test.py
@@ -134,6 +134,19 @@ class TestQueueInit(TestCase):
         self.assertTrue(q.drain)
         self.assertFalse(q.batch)
 
+    def test_stores_bulk_queue(self):
+        mock_queue = MagicMock()
+        mock_bulk_queue = MagicMock()
+        with patch('sqs_queue.signal'):
+            q = Queue(queue=mock_queue, bulk_queue=mock_bulk_queue)
+        self.assertIs(q.bulk_queue, mock_bulk_queue)
+
+    def test_bulk_queue_defaults_to_none(self):
+        mock_queue = MagicMock()
+        with patch('sqs_queue.signal'):
+            q = Queue(queue=mock_queue)
+        self.assertIsNone(q.bulk_queue)
+
 
 class TestQueueIter(TestCase):
 
@@ -342,6 +355,165 @@ class TestQueueConsumer(TestCase):
             list(consumer)
         mock_sleep.assert_called_with(30)
 
+    @patch('sqs_queue.sleep')
+    def test_yields_from_bulk_queue_when_main_queue_empty(self, mock_sleep):
+        mock_queue = MagicMock()
+        mock_bulk_queue = MagicMock()
+        mock_sqs_msg1 = MagicMock()
+        mock_sqs_msg1.message_id = 'bulk-1'
+        mock_sqs_msg2 = MagicMock()
+        mock_sqs_msg2.message_id = 'bulk-2'
+        bulk_messages = [
+            Message({'bulk': 1}, mock_bulk_queue, mock_sqs_msg1),
+            Message({'bulk': 2}, mock_bulk_queue, mock_sqs_msg2),
+        ]
+        mock_bulk_queue.receive.side_effect = [bulk_messages, []]
+        with patch('sqs_queue.signal'):
+            q = Queue(queue=mock_queue, bulk_queue=mock_bulk_queue, drain=False)
+            q.got_sigterm = False
+            # First poll returns empty, second poll after bulk processing also empty
+            mock_queue.receive_messages.side_effect = [[], []]
+
+            def set_sigterm(*args):
+                q.got_sigterm = True
+            mock_sleep.side_effect = set_sigterm
+            messages = list(q)
+        self.assertEqual(len(messages), 2)
+        self.assertEqual(messages[0]['bulk'], 1)
+        self.assertEqual(messages[1]['bulk'], 2)
+
+    @patch('sqs_queue.sleep')
+    def test_deletes_bulk_queue_messages_after_processing(self, mock_sleep):
+        mock_queue = MagicMock()
+        mock_bulk_queue = MagicMock()
+        mock_sqs_msg1 = MagicMock()
+        mock_sqs_msg1.message_id = 'bulk-1'
+        mock_sqs_msg2 = MagicMock()
+        mock_sqs_msg2.message_id = 'bulk-2'
+        bulk_messages = [
+            Message({'bulk': 1}, mock_bulk_queue, mock_sqs_msg1),
+            Message({'bulk': 2}, mock_bulk_queue, mock_sqs_msg2),
+        ]
+        mock_bulk_queue.receive.side_effect = [bulk_messages, []]
+        with patch('sqs_queue.signal'):
+            q = Queue(queue=mock_queue, bulk_queue=mock_bulk_queue, drain=False)
+            q.got_sigterm = False
+            mock_queue.receive_messages.side_effect = [[], []]
+
+            def set_sigterm(*args):
+                q.got_sigterm = True
+            mock_sleep.side_effect = set_sigterm
+            list(q)
+        mock_sqs_msg1.delete.assert_called_once()
+        mock_sqs_msg2.delete.assert_called_once()
+
+    @patch('sqs_queue.sleep')
+    def test_does_not_sleep_after_yielding_bulk_messages(self, mock_sleep):
+        mock_queue = MagicMock()
+        mock_bulk_queue = MagicMock()
+        mock_sqs_msg = MagicMock()
+        mock_sqs_msg.message_id = 'bulk-1'
+        bulk_messages = [Message({'bulk': 1}, mock_bulk_queue, mock_sqs_msg)]
+        mock_bulk_queue.receive.side_effect = [bulk_messages, []]
+        with patch('sqs_queue.signal'):
+            q = Queue(queue=mock_queue, bulk_queue=mock_bulk_queue, drain=False)
+            q.got_sigterm = False
+            # First poll empty (triggers bulk), second poll empty (triggers sleep)
+            mock_queue.receive_messages.side_effect = [[], []]
+
+            def set_sigterm(*args):
+                q.got_sigterm = True
+            mock_sleep.side_effect = set_sigterm
+            list(q)
+        # Should have polled twice: once before bulk, once after bulk (then sleep)
+        self.assertEqual(mock_queue.receive_messages.call_count, 2)
+        # Sleep only called once (after second empty poll when bulk is exhausted)
+        mock_sleep.assert_called_once()
+
+    @patch('sqs_queue.sleep')
+    def test_sleeps_when_bulk_queue_empty(self, mock_sleep):
+        mock_queue = MagicMock()
+        mock_queue.receive_messages.return_value = []
+        mock_bulk_queue = MagicMock()
+        mock_bulk_queue.receive.return_value = []
+        with patch('sqs_queue.signal'):
+            q = Queue(queue=mock_queue, bulk_queue=mock_bulk_queue, drain=False)
+            q.got_sigterm = False
+
+            def set_sigterm(*args):
+                q.got_sigterm = True
+            mock_sleep.side_effect = set_sigterm
+            list(q)
+        # Should sleep since bulk queue had no messages
+        mock_sleep.assert_called_once()
+
+    @patch('sqs_queue.sleep')
+    def test_bulk_queue_receive_called_with_max_count_batch_true(self, mock_sleep):
+        mock_queue = MagicMock()
+        mock_queue.receive_messages.return_value = []
+        mock_bulk_queue = MagicMock()
+        mock_bulk_queue.receive.return_value = []
+        with patch('sqs_queue.signal'):
+            q = Queue(queue=mock_queue, bulk_queue=mock_bulk_queue, drain=False, batch=True)
+            q.got_sigterm = False
+
+            def set_sigterm(*args):
+                q.got_sigterm = True
+            mock_sleep.side_effect = set_sigterm
+            list(q)
+        # batch=True means max_count=10
+        mock_bulk_queue.receive.assert_called_with(10)
+
+    @patch('sqs_queue.sleep')
+    def test_bulk_queue_receive_called_with_max_count_batch_false(self, mock_sleep):
+        mock_queue = MagicMock()
+        mock_queue.receive_messages.return_value = []
+        mock_bulk_queue = MagicMock()
+        mock_bulk_queue.receive.return_value = []
+        with patch('sqs_queue.signal'):
+            q = Queue(queue=mock_queue, bulk_queue=mock_bulk_queue, drain=False, batch=False)
+            q.got_sigterm = False
+
+            def set_sigterm(*args):
+                q.got_sigterm = True
+            mock_sleep.side_effect = set_sigterm
+            list(q)
+        # batch=False means max_count=1
+        mock_bulk_queue.receive.assert_called_with(1)
+
+    def test_drain_mode_also_drains_bulk_queue(self):
+        mock_queue = MagicMock()
+        mock_queue.receive_messages.return_value = []
+        mock_bulk_queue = MagicMock()
+        mock_sqs_msg = MagicMock()
+        mock_sqs_msg.message_id = 'bulk-1'
+        bulk_message = Message({'bulk': 1}, mock_bulk_queue, mock_sqs_msg)
+        mock_bulk_queue.receive.side_effect = [[bulk_message], []]
+        with patch('sqs_queue.signal'):
+            q = Queue(queue=mock_queue, bulk_queue=mock_bulk_queue, drain=True)
+            q.got_sigterm = False
+            messages = list(q)
+        # drain=True should also drain bulk_queue
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0]['bulk'], 1)
+
+    def test_bulk_queue_not_checked_when_main_queue_has_messages(self):
+        mock_queue = MagicMock()
+        mock_message = MagicMock()
+        mock_message.body = '{"key": "value"}'
+        mock_message.message_id = 'msg-1'
+        mock_message.attributes = {}
+        # First receive returns message, bulk_queue not checked
+        mock_queue.receive_messages.return_value = [mock_message]
+        mock_bulk_queue = MagicMock()
+        with patch('sqs_queue.signal'):
+            q = Queue(queue=mock_queue, bulk_queue=mock_bulk_queue, drain=True)
+            q.got_sigterm = False
+            consumer = iter(q)
+            # Process first message - bulk_queue should not be checked yet
+            next(consumer)
+        mock_bulk_queue.receive.assert_not_called()
+
     def test_puts_unprocessed_messages_back_on_sigterm(self):
         mock_queue = MagicMock()
         mock_message1 = MagicMock()
@@ -399,6 +571,177 @@ class TestQueueConsumer(TestCase):
         entries = mock_queue.change_message_visibility_batch.call_args[1]['Entries']
         self.assertEqual(len(entries), 1)
         self.assertEqual(entries[0]['ReceiptHandle'], 'handle-2')
+
+
+class TestQueueReceive(TestCase):
+
+    def test_receive_returns_messages(self):
+        mock_queue = MagicMock()
+        mock_sqs_message = MagicMock()
+        mock_sqs_message.body = '{"key": "value"}'
+        mock_sqs_message.message_id = 'msg-1'
+        mock_queue.receive_messages.return_value = [mock_sqs_message]
+        with patch('sqs_queue.signal'):
+            q = Queue(queue=mock_queue)
+            messages = q.receive()
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0]['key'], 'value')
+        self.assertIs(messages[0].sqs_message, mock_sqs_message)
+
+    def test_receive_uses_wait_time_zero(self):
+        mock_queue = MagicMock()
+        mock_queue.receive_messages.return_value = []
+        with patch('sqs_queue.signal'):
+            q = Queue(queue=mock_queue)
+            q.receive()
+        mock_queue.receive_messages.assert_called_once_with(
+            MaxNumberOfMessages=10,
+            WaitTimeSeconds=0,
+            MessageAttributeNames=['All'],
+            AttributeNames=['All']
+        )
+
+    def test_receive_respects_max_count(self):
+        mock_queue = MagicMock()
+        mock_queue.receive_messages.return_value = []
+        with patch('sqs_queue.signal'):
+            q = Queue(queue=mock_queue)
+            q.receive(max_count=5)
+        mock_queue.receive_messages.assert_called_once_with(
+            MaxNumberOfMessages=5,
+            WaitTimeSeconds=0,
+            MessageAttributeNames=['All'],
+            AttributeNames=['All']
+        )
+
+    def test_receive_skips_invalid_json(self):
+        mock_queue = MagicMock()
+        valid_msg = MagicMock()
+        valid_msg.body = '{"key": "value"}'
+        valid_msg.message_id = 'msg-1'
+        invalid_msg = MagicMock()
+        invalid_msg.body = 'not json'
+        invalid_msg.message_id = 'msg-2'
+        mock_queue.receive_messages.return_value = [valid_msg, invalid_msg]
+        with patch('sqs_queue.signal'):
+            q = Queue(queue=mock_queue)
+            messages = q.receive()
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0]['key'], 'value')
+
+    def test_receive_returns_empty_list_when_no_messages(self):
+        mock_queue = MagicMock()
+        mock_queue.receive_messages.return_value = []
+        with patch('sqs_queue.signal'):
+            q = Queue(queue=mock_queue)
+            messages = q.receive()
+        self.assertEqual(messages, [])
+
+    def test_receive_uses_wait_parameter(self):
+        mock_queue = MagicMock()
+        mock_queue.receive_messages.return_value = []
+        with patch('sqs_queue.signal'):
+            q = Queue(queue=mock_queue)
+            q.receive(max_count=5, wait=20)
+        mock_queue.receive_messages.assert_called_once_with(
+            MaxNumberOfMessages=5,
+            WaitTimeSeconds=20,
+            MessageAttributeNames=['All'],
+            AttributeNames=['All']
+        )
+
+
+class TestParseJson(TestCase):
+
+    def test_returns_parsed_body_for_valid_json(self):
+        mock_queue = MagicMock()
+        with patch('sqs_queue.signal'):
+            q = Queue(queue=mock_queue)
+        message = MagicMock()
+        message.body = '{"key": "value"}'
+        result = q._parse_json(message)
+        self.assertEqual(result, {'key': 'value'})
+
+    def test_returns_none_for_invalid_json(self):
+        mock_queue = MagicMock()
+        with patch('sqs_queue.signal'):
+            q = Queue(queue=mock_queue)
+        message = MagicMock()
+        message.body = 'not valid json'
+        message.message_id = 'msg-1'
+        self.assertIsNone(q._parse_json(message))
+
+
+class TestUnwrapSns(TestCase):
+
+    def test_unwraps_sns_message_in_place(self):
+        mock_queue = MagicMock()
+        with patch('sqs_queue.signal'):
+            q = Queue(queue=mock_queue)
+        mock_sqs_message = MagicMock()
+        message = Message({
+            'MessageId': 'sns-msg-id',
+            'SequenceNumber': '123',
+            'Timestamp': '2021-01-01T00:00:00Z',
+            'Message': '{"data": "test"}'
+        }, q, mock_sqs_message)
+        result = q._unwrap_sns(message)
+        self.assertTrue(result)
+        self.assertEqual(message['data'], 'test')
+        self.assertEqual(message['sns_message_id'], 'sns-msg-id')
+        self.assertEqual(message['sns_sequence_number'], '123')
+        self.assertEqual(message['sns_timestamp'], '2021-01-01T00:00:00Z')
+        self.assertNotIn('MessageId', message)
+        self.assertNotIn('Message', message)
+
+    def test_returns_false_for_invalid_inner_json(self):
+        mock_queue = MagicMock()
+        with patch('sqs_queue.signal'):
+            q = Queue(queue=mock_queue)
+        mock_sqs_message = MagicMock()
+        mock_sqs_message.message_id = 'msg-1'
+        message = Message({
+            'MessageId': 'sns-msg-id',
+            'Message': 'not valid json'
+        }, q, mock_sqs_message)
+        result = q._unwrap_sns(message)
+        self.assertFalse(result)
+
+    def test_returns_false_for_missing_message_id(self):
+        mock_queue = MagicMock()
+        with patch('sqs_queue.signal'):
+            q = Queue(queue=mock_queue)
+        mock_sqs_message = MagicMock()
+        mock_sqs_message.message_id = 'msg-1'
+        message = Message({
+            'Message': '{"data": "test"}'
+        }, q, mock_sqs_message)
+        result = q._unwrap_sns(message)
+        self.assertFalse(result)
+
+
+class TestDeleteMessage(TestCase):
+
+    def test_deletes_sqs_message(self):
+        mock_queue = MagicMock()
+        with patch('sqs_queue.signal'):
+            q = Queue(queue=mock_queue)
+        mock_sqs_message = MagicMock()
+        mock_sqs_message.message_id = 'msg-1'
+        message = Message({'key': 'value'}, q, mock_sqs_message)
+        q._delete_message(message)
+        mock_sqs_message.delete.assert_called_once()
+
+    def test_handles_delete_exception(self):
+        mock_queue = MagicMock()
+        with patch('sqs_queue.signal'):
+            q = Queue(queue=mock_queue)
+        mock_sqs_message = MagicMock()
+        mock_sqs_message.message_id = 'msg-1'
+        mock_sqs_message.delete.side_effect = Exception('delete failed')
+        message = Message({'key': 'value'}, q, mock_sqs_message)
+        # Should not raise
+        q._delete_message(message)
 
 
 class TestQueuePublish(TestCase):

--- a/test.py
+++ b/test.py
@@ -1,10 +1,14 @@
 import json
+import logging
 from datetime import datetime, timezone
 from signal import SIGTERM, SIG_DFL
 from unittest import TestCase
 from unittest.mock import MagicMock, patch, call
 
 from sqs_queue import Message, Queue, utc_from_timestamp
+
+# Disable all logging output for the entire test suite
+logging.disable(logging.CRITICAL)
 
 
 class TestUtcFromTimestamp(TestCase):


### PR DESCRIPTION
### Jira URL
https://cds-global.atlassian.net/browse/PDT-3647

### Description
                                                                  
  Adds support for a secondary "bulk queue" that is checked when the primary queue is empty. This enables priority-based message processing where high-priority messages in the primary queue are always processed first, while bulk/background work is processed during idle periods.

Other improvements:
- Override or set `Queue()` options from `SQS_QUEUE_` env vars
- You can `queue.publish(`_a dict instead of a string_`)`
- Added a `Dockerfile` and `compose.yaml` for easy local testing

Bumped the version to 1.0.0! This has been used in production for years, and is pretty well feature-complete now.

### Prompts for Opus 4.5

> I've added an optional "bulk_queue" param to Queue, which accepts another Queue object that is checked only when the main queue is empty. Check my work, and add unit tests for the new feature.

> I see an error: if there are messages in the bulk queue, we shouldn't sleep after yielding them for processing - we should immediately poll the primary queue again.

> I think I see a design flaw: I want to check the bulk queue when the primary queue is empty, but I don't want to wait for it - I want to just get and yield up to max_count messages, then return to checking the primary queue.

> If we have a .receive() method, we should use it for polling the primary queue as well.                                                                                                                      

> I don't like calling json.loads(message.body) twice like that just to validate the JSON before actually loading it.                                                                                          

> The nested loops are very similar, although the outer loop calls _unwrap_sns() which the inner loop should too. Can we make the code neater and less repetitive?

### Key changes:

  - New `bulk_queue` parameter on `Queue.__init__()` accepts another `Queue` instance
  - New `receive(max_count, wait)` method for non-blocking message retrieval
  - Refactored message processing into reusable `_process_messages()` generator

  ### Motivation

  In systems where some messages are time-sensitive while others are bulk operations, we need a way to prioritize. Rather than implementing complex priority logic, this uses two separate queues: a primary queue that's polled with long-polling, and a bulk queue that's checked (non-blocking) only when the primary is empty.

  ### How it works

  ```python
  bulk = Queue(queue_name='bulk-queue')
  primary = Queue(queue_name='priority-queue', bulk_queue=bulk)

  for message in primary:
      process(message)  # Processes primary first, bulk when primary is empty
  ```

  **Flow:**
  1. Long-poll primary queue (with `poll_wait` timeout)
  2. Process any messages received
  3. If primary was empty, do a **non-blocking** check of bulk queue
  4. If bulk has messages, process them then immediately re-poll primary (no sleep)
  5. If both queues are empty, sleep for `poll_sleep` seconds
  6. Repeat

  ### API additions

  #### `Queue.__init__(bulk_queue=None)`
  Optional `Queue` instance to check when primary queue is empty.

  #### `Queue.receive(max_count=10, wait=0)`
  Returns up to `max_count` `Message` objects. The `wait` parameter controls long-polling:
  - `wait=0` (default): Non-blocking, returns immediately
  - `wait=N`: Long-poll for up to N seconds

  ### Refactoring

  Extracted several helper methods to reduce code duplication:

  | Method                        | Purpose                                                                      |
  | ----------------------------- | ---------------------------------------------------------------------------- |
  | `_process_messages(messages)` | Generator that yields messages, handles SNS unwrapping, deletion, and SIGTERM |
  | `_unwrap_sns(message)`        | Unwraps SNS envelope in place                                                |
  | `_delete_message(message)`    | Deletes message with error handling                                          |
  | `_parse_json(sqs_message)`    | Parses JSON body, returns `None` on failure                                  |

  Both primary and bulk queues now use identical processing logic via `_process_messages()`.

  ### Test plan

  - [x] Bulk queue messages are yielded when primary is empty
  - [x] Bulk queue uses non-blocking receive (`wait=0`)
  - [x] No sleep after processing bulk messages (immediately re-polls primary)
  - [x] Sleep occurs when both queues are empty
  - [x] Bulk queue respects `max_count` (batch=True → 10, batch=False → 1)
  - [x] Bulk queue not checked when `drain=True`
  - [x] Bulk queue messages are deleted after processing
  - [x] SNS unwrapping works for bulk queue messages
  - [x] SIGTERM handling works correctly

  **Test coverage:** 60 tests, all passing
